### PR TITLE
Remove http.sslVerify from Usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ The Rancher UI will need a FQDN which load balances the connections toward the R
 ### Clone repository
 
 ```bash
-git config --global http.sslVerify false
-https://github.com/SUSE-South-EMEA/rancher-poc.git
+git clone https://github.com/SUSE-South-EMEA/rancher-poc.git
 cd rancher-poc
 ```
 


### PR DESCRIPTION
I suspect that `git config --global http.sslVerify false` is a
remnant of previously configured git repository, however, it is
not recommended to use on repositories with valid certificates.
This PR removes that instruction and also adds a full
`git clone` command